### PR TITLE
ElementwiseSequenceEqualityComparer fix when element is null

### DIFF
--- a/Sources/Equ.Test/ElementwiseSequenceEqualityComparerTest.cs
+++ b/Sources/Equ.Test/ElementwiseSequenceEqualityComparerTest.cs
@@ -35,5 +35,33 @@
             Assert.False(comparer.Equals(e1, e2));
             Assert.False(comparer.Equals(e2, e1));
         }
+
+        [Fact]
+        public void Null_values_are_reported_equal()
+        {
+            var e1 = new string[] { null };
+            var e2 = new List<string> { null };
+
+            var comparer = new ElementwiseSequenceEqualityComparer<IEnumerable<string>>();
+
+            Assert.True(comparer.Equals(e1, e1));
+            Assert.True(comparer.Equals(e1, e2));
+            Assert.True(comparer.Equals(e2, e1));
+            Assert.True(comparer.Equals(e2, e2));
+
+            Assert.Equal(comparer.GetHashCode(e1), comparer.GetHashCode(e2));
+        }
+
+        [Fact]
+        public void Null_and_non_null_values_are_reported_different()
+        {
+            var e1 = new[] { "abc" };
+            var e2 = new List<string> { null };
+
+            var comparer = new ElementwiseSequenceEqualityComparer<IEnumerable<string>>();
+
+            Assert.False(comparer.Equals(e1, e2));
+            Assert.False(comparer.Equals(e2, e1));
+        }
     }
 }

--- a/Sources/Equ/ElementwiseSequenceEqualityComparer.cs
+++ b/Sources/Equ/ElementwiseSequenceEqualityComparer.cs
@@ -48,7 +48,7 @@
 
             unchecked
             {
-                return obj.Cast<object>().Aggregate(17, (current, o) => (current * 486187739) ^ o.GetHashCode());
+                return obj.Cast<object>().Aggregate(17, (current, o) => (current * 486187739) ^ (o == null ? 0 : o.GetHashCode()));
             }
         }
     }


### PR DESCRIPTION
`comparer.GetHashCode` failed when an enumerable contained a null value.
Reproduce> Check the Null_values_are_reported_equal method in the PR, earlier it failed.

This PR fixes that problem.