### PR TITLE
Fix exception when type has an indexed property

### DIFF
--- a/Sources/Equ.Test/ElementwiseSequenceEqualityComparerTest.cs
+++ b/Sources/Equ.Test/ElementwiseSequenceEqualityComparerTest.cs
@@ -63,5 +63,53 @@
             Assert.False(comparer.Equals(e1, e2));
             Assert.False(comparer.Equals(e2, e1));
         }
+
+        [Fact]
+        public void Dictionaries_compare_equal()
+        {
+            var dict1 = new Dictionary<string, int>
+            {
+                ["abc"] = 1,
+                ["cde"] = 2
+            };
+            var dict2 = new Dictionary<string, int>
+            {
+                ["cde"] = 2,
+                ["abc"] = 1
+            };
+
+            var comparer = new ElementwiseSequenceEqualityComparer<Dictionary<string, int>>();
+
+            Assert.True(comparer.Equals(dict1, dict2));
+            Assert.True(comparer.Equals(dict2, dict1));
+
+            Assert.Equal(comparer.GetHashCode(dict1), comparer.GetHashCode(dict2));
+        }
+
+        [Fact]
+        public void Dictionaries_compare_different()
+        {
+            var dict1 = new Dictionary<string, int>
+            {
+                ["abc"] = 1,
+                ["cde"] = 2
+            };
+            var dict2 = new Dictionary<string, int>
+            {
+                ["cde"] = 2,
+                ["abc"] = 1,
+                ["fgh"] = 3
+            };
+            var dict3 = new Dictionary<string, int>
+            {
+                ["abc"] = 2,
+                ["cde"] = 2
+            };
+
+            var comparer = new ElementwiseSequenceEqualityComparer<Dictionary<string, int>>();
+
+            Assert.False(comparer.Equals(dict1, dict2));
+            Assert.False(comparer.Equals(dict1, dict3));
+        }
     }
 }

--- a/Sources/Equ.Test/Equ.Test.csproj
+++ b/Sources/Equ.Test/Equ.Test.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <ApplicationIcon />
     <OutputTypeEx>exe</OutputTypeEx>
     <StartupObject />

--- a/Sources/Equ.Test/PropertywiseEquatableTest.cs
+++ b/Sources/Equ.Test/PropertywiseEquatableTest.cs
@@ -53,6 +53,15 @@
             Assert.NotEqual(x.GetHashCode(), y.GetHashCode());
         }
 
+        [Fact]
+        public void Ignore_index_properties()
+        {
+            var v1 = new IndexedValueType(15);
+            var v2 = new IndexedValueType(15);
+
+            Assert.Equal(v1, v2);
+        }
+
         private class ValueType : PropertywiseEquatable<ValueType>
         {
             public ValueType(string x, int y)
@@ -66,6 +75,24 @@
 
             // ReSharper disable once UnusedAutoPropertyAccessor.Local
             public int Y { get; private set; }
+        }
+
+        private class IndexedValueType : PropertywiseEquatable<IndexedValueType>
+        {
+            public IndexedValueType(int value)
+            {
+                Value = value;
+            }
+
+            public int Value { get; private set; }
+
+            public string this[string val]
+            {
+                get
+                {
+                    return val;
+                }
+            }
         }
     }
 }

--- a/Sources/Equ/Equ.csproj
+++ b/Sources/Equ/Equ.csproj
@@ -1,19 +1,30 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.5</TargetFramework>
-    <AssemblyVersion>2.0.2</AssemblyVersion>
-    <FileVersion>2.0.2</FileVersion>
-    <Version>2.0.2</Version>
-    <Authors>Dani Michel</Authors>
-    <Company>Dani Michel</Company>
+    <TargetFrameworks>netstandard1.5;netstandard2.0</TargetFrameworks>
+    <AssemblyVersion>2.0.4</AssemblyVersion>
+    <FileVersion>2.0.4</FileVersion>
+    <Version>2.0.4</Version>
+    <Authors>Devon Richards</Authors>
+    <Company>Devon Richards</Company>
     <Description>Fast, convention-based, zero-code equality functions</Description>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <PackageLicenseUrl>http://opensource.org/licenses/MIT</PackageLicenseUrl>
-    <PackageProjectUrl>https://github.com/thedmi/Equ</PackageProjectUrl>
+    <PackageLicenseUrl></PackageLicenseUrl>
+    <PackageProjectUrl>https://github.com/ruler501/Equ</PackageProjectUrl>
     <PackageTags>equality, iequatable, generator</PackageTags>
-    <Copyright>Dani Michel</Copyright>
-    <PackageReleaseNotes>See https://github.com/thedmi/Equ/blob/master/ReleaseNotes.md</PackageReleaseNotes>
+    <Copyright>Devon Richards</Copyright>
+    <PackageReleaseNotes>See https://github.com/ruler501/Equ/blob/master/ReleaseNotes.md</PackageReleaseNotes>
+    <PackageId>ruler501.Equ</PackageId>
+    <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
+    <RepositoryUrl>https://github.com/ruler501/Equ</RepositoryUrl>
+    <RepositoryType>Git</RepositoryType>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\..\LICENSE.txt">
+      <Pack>True</Pack>
+      <PackagePath></PackagePath>
+    </None>
+  </ItemGroup>
 
 </Project>

--- a/Sources/Equ/MemberwiseEqualityComparer.cs
+++ b/Sources/Equ/MemberwiseEqualityComparer.cs
@@ -59,12 +59,20 @@
 
         private static IEnumerable<FieldInfo> AllFieldsExceptIgnored(Type t)
         {
-            return t.GetTypeInfo().GetFields(AllInstanceMembers).Where(IsNotMarkedAsIgnore);
+            List<FieldInfo> fieldInfo = t.GetTypeInfo().GetFields(AllInstanceMembers).Where(IsNotMarkedAsIgnore).OrderBy(f => f.Name).ToList();
+            fieldInfo.Sort((i1, i2) => i1.Name.CompareTo(i2.Name));
+
+            return fieldInfo;
         }
 
         private static IEnumerable<PropertyInfo> AllPropertiesExceptIgnored(Type t)
         {
-            return t.GetTypeInfo().GetProperties(AllInstanceMembers).Where(info => IsNotMarkedAsIgnore(info) && IsNotIndexed(info));
+            List<PropertyInfo> propertyInfo = t.GetTypeInfo().GetProperties(AllInstanceMembers)
+                                                             .Where(p => IsNotMarkedAsIgnore(p) && IsNotIndexed(p))
+                                                             .OrderBy(p => p.Name).ToList();
+            propertyInfo.Sort((i1, i2) => i1.Name.CompareTo(i2.Name));
+
+            return propertyInfo;
         }
 
         private static BindingFlags AllInstanceMembers

--- a/Sources/Equ/MemberwiseEqualityComparer.cs
+++ b/Sources/Equ/MemberwiseEqualityComparer.cs
@@ -64,7 +64,7 @@
 
         private static IEnumerable<PropertyInfo> AllPropertiesExceptIgnored(Type t)
         {
-            return t.GetTypeInfo().GetProperties(AllInstanceMembers).Where(IsNotMarkedAsIgnore);
+            return t.GetTypeInfo().GetProperties(AllInstanceMembers).Where(info => IsNotMarkedAsIgnore(info) && IsNotIndexed(info));
         }
 
         private static BindingFlags AllInstanceMembers
@@ -80,6 +80,13 @@
             var isPropertyIgnored = propertyInfo != null && propertyInfo.GetCustomAttributes(typeof(MemberwiseEqualityIgnoreAttribute), true).Any();
 
             return !isSelfIgnored && !isPropertyIgnored;
+        }
+
+        private static bool IsNotIndexed(PropertyInfo propertyInfo)
+        {
+            var indexParamaters = propertyInfo.GetIndexParameters();
+
+            return indexParamaters.Count() == 0;
         }
 
         private static PropertyInfo GetPropertyForBackingField(MemberInfo memberInfo)


### PR DESCRIPTION
Added code to ignore indexed properties and a test to show why this was needed.