### PR TITLE
Add support for dictionary properties

### DIFF
--- a/Sources/Equ.Test/ElementwiseSequenceEqualityComparerTest.cs
+++ b/Sources/Equ.Test/ElementwiseSequenceEqualityComparerTest.cs
@@ -63,5 +63,53 @@
             Assert.False(comparer.Equals(e1, e2));
             Assert.False(comparer.Equals(e2, e1));
         }
+
+        [Fact]
+        public void Dictionaries_compare_equal()
+        {
+            var dict1 = new Dictionary<string, int>
+            {
+                ["abc"] = 1,
+                ["cde"] = 2
+            };
+            var dict2 = new Dictionary<string, int>
+            {
+                ["cde"] = 2,
+                ["abc"] = 1
+            };
+
+            var comparer = new ElementwiseSequenceEqualityComparer<Dictionary<string, int>>();
+
+            Assert.True(comparer.Equals(dict1, dict2));
+            Assert.True(comparer.Equals(dict2, dict1));
+
+            Assert.Equal(comparer.GetHashCode(dict1), comparer.GetHashCode(dict2));
+        }
+
+        [Fact]
+        public void Dictionaries_compare_different()
+        {
+            var dict1 = new Dictionary<string, int>
+            {
+                ["abc"] = 1,
+                ["cde"] = 2
+            };
+            var dict2 = new Dictionary<string, int>
+            {
+                ["cde"] = 2,
+                ["abc"] = 1,
+                ["fgh"] = 3
+            };
+            var dict3 = new Dictionary<string, int>
+            {
+                ["abc"] = 2,
+                ["cde"] = 2
+            };
+
+            var comparer = new ElementwiseSequenceEqualityComparer<Dictionary<string, int>>();
+
+            Assert.False(comparer.Equals(dict1, dict2));
+            Assert.False(comparer.Equals(dict1, dict3));
+        }
     }
 }

--- a/Sources/Equ/MemberwiseEqualityComparer.cs
+++ b/Sources/Equ/MemberwiseEqualityComparer.cs
@@ -59,12 +59,14 @@
 
         private static IEnumerable<FieldInfo> AllFieldsExceptIgnored(Type t)
         {
-            return t.GetTypeInfo().GetFields(AllInstanceMembers).Where(IsNotMarkedAsIgnore);
+            return t.GetTypeInfo().GetFields(AllInstanceMembers).Where(IsNotMarkedAsIgnore)
+                    .OrderBy(f => f.Name).ToList();
         }
 
         private static IEnumerable<PropertyInfo> AllPropertiesExceptIgnored(Type t)
         {
-            return t.GetTypeInfo().GetProperties(AllInstanceMembers).Where(IsNotMarkedAsIgnore);
+            return t.GetTypeInfo().GetProperties(AllInstanceMembers).Where(IsNotMarkedAsIgnore)
+                    .OrderBy(p => p.Name).ToList();
         }
 
         private static BindingFlags AllInstanceMembers


### PR DESCRIPTION
Currently if there is a dictionary we treat it the same as any other enumerable and do position dependent comparison. This isn't valid for dictionaries where the order can be semi random. There are associated tests to demonstrate the cases this fixed.