### PR TITLE
ToString() function generator (experimental)

### DIFF
--- a/Sources/Equ.Test/ElementwiseSequenceEqualityComparerTest.cs
+++ b/Sources/Equ.Test/ElementwiseSequenceEqualityComparerTest.cs
@@ -3,7 +3,6 @@
     using System.Collections;
     using System.Collections.Generic;
     using System.Collections.ObjectModel;
-    using System.Reflection;
 
     using Equ;
 

--- a/Sources/Equ.Test/MemberwiseEquatableTest.cs
+++ b/Sources/Equ.Test/MemberwiseEquatableTest.cs
@@ -145,8 +145,6 @@ namespace Equ.Test
             Assert.Equal(v1, v2);
         }
 
-        // TODO Add sequence equality tests
-
         // ReSharper disable NotAccessedField.Local
         private class ValueType : MemberwiseEquatable<ValueType>
         {

--- a/Sources/Equ.Test/ToStringFunctionGeneratorTest.cs
+++ b/Sources/Equ.Test/ToStringFunctionGeneratorTest.cs
@@ -1,25 +1,11 @@
 namespace Equ.Test
 {
-    using System;
-    using System.Collections;
     using System.Collections.Generic;
-    using System.Linq;
-    using System.Linq.Expressions;
-    using System.Reflection;
-    using System.Text.RegularExpressions;
 
     using Xunit;
-    using Xunit.Abstractions;
 
     public class ToStringFunctionGeneratorTest
     {
-        private readonly ITestOutputHelper _output;
-
-        public ToStringFunctionGeneratorTest(ITestOutputHelper output)
-        {
-            _output = output;
-        }
-
         [Fact]
         public void String_representations_contain_all_information()
         {
@@ -36,11 +22,17 @@ namespace Equ.Test
         }
 
         [Fact]
-        public void Null_values_are_converted_to_null_strings()
+        public void Null_fields_are_converted_to_null_strings()
         {
             var obj = new SomeType1(0, null, null, null, null);
             
-            Assert.Equal("", obj.ToString());
+            Assert.Equal("{ _anIntegerArray: ∅, _aDictionary: ∅, SomeInteger: 0, SomeString: ∅, SomeType2S: ∅ }", obj.ToString());
+        }
+
+        [Fact]
+        public void Null_instances_are_converted_to_null_strings()
+        {
+            Assert.Equal("∅", Stringify<SomeType1>.With(null));
         }
         
         // ReSharper disable UnusedAutoPropertyAccessor.Local

--- a/Sources/Equ.Test/ToStringFunctionGeneratorTest.cs
+++ b/Sources/Equ.Test/ToStringFunctionGeneratorTest.cs
@@ -1,0 +1,93 @@
+namespace Equ.Test
+{
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Linq.Expressions;
+    using System.Reflection;
+    using System.Text.RegularExpressions;
+
+    using Xunit;
+    using Xunit.Abstractions;
+
+    public class ToStringFunctionGeneratorTest
+    {
+        private readonly ITestOutputHelper _output;
+
+        public ToStringFunctionGeneratorTest(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        [Fact]
+        public void String_representations_contain_all_information()
+        {
+            var obj = new SomeType1(
+                12,
+                "uga",
+                new[] { new SomeType2(true, 42.8), new SomeType2(false, double.NaN) },
+                new[] { 1, 2, 3, 4 },
+                new Dictionary<string, SomeType2> { { "foo", new SomeType2(false, 13.1) } });
+
+            Assert.Equal(
+                "{ _anIntegerArray: [ 1, 2, 3, 4 ], _aDictionary: [ [foo, { SomeBool: False, SomeDouble: 13.1 }] ], SomeInteger: 12, SomeString: uga, SomeType2S: [ { SomeBool: True, SomeDouble: 42.8 }, { SomeBool: False, SomeDouble: NaN } ] }",
+                obj.ToString());
+        }
+
+        [Fact]
+        public void Null_values_are_converted_to_null_strings()
+        {
+            var obj = new SomeType1(0, null, null, null, null);
+            
+            Assert.Equal("", obj.ToString());
+        }
+        
+        // ReSharper disable UnusedAutoPropertyAccessor.Local
+        // ReSharper disable NotAccessedField.Local
+        private class SomeType1
+        {
+            private readonly int[] _anIntegerArray;
+
+            private readonly IDictionary<string, SomeType2> _aDictionary;
+
+            public SomeType1(int someInteger, string someString, IReadOnlyList<SomeType2> someType2S, int[] anIntegerArray, IDictionary<string, SomeType2> aDictionary)
+            {
+                _anIntegerArray = anIntegerArray;
+                _aDictionary = aDictionary;
+                
+                SomeInteger = someInteger;
+                SomeType2S = someType2S;
+                SomeString = someString;
+            }
+
+            public int SomeInteger { get; }
+            
+            public string SomeString { get; }
+            
+            public IReadOnlyList<SomeType2> SomeType2S { get; }
+
+            public override string ToString()
+            {
+                return Stringify<SomeType1>.With(this);
+            }
+        }
+
+        private class SomeType2
+        {
+            public SomeType2(bool someBool, double someDouble)
+            {
+                SomeBool = someBool;
+                SomeDouble = someDouble;
+            }
+
+            public bool SomeBool { get; }
+
+            public double SomeDouble { get; }
+
+            public override string ToString() => Stringify<SomeType2>.With(this);
+        }
+        // ReSharper restore NotAccessedField.Local
+        // ReSharper restore UnusedAutoPropertyAccessor.Local
+    }
+}

--- a/Sources/Equ.Test/ValueObjectWithDictionaryEqualityTest.cs
+++ b/Sources/Equ.Test/ValueObjectWithDictionaryEqualityTest.cs
@@ -3,8 +3,6 @@ namespace Equ.Test
     using System.Collections.Generic;
     using System.Collections.ObjectModel;
 
-    using Microsoft.VisualStudio.TestPlatform.ObjectModel;
-
     using Xunit;
 
     public class ValueObjectWithDictionaryEqualityTest

--- a/Sources/Equ/ElementwiseSequenceEqualityComparer.cs
+++ b/Sources/Equ/ElementwiseSequenceEqualityComparer.cs
@@ -1,6 +1,5 @@
 ﻿namespace Equ
 {
-    using System;
     using System.Collections;
     using System.Collections.Generic;
     using System.Linq;

--- a/Sources/Equ/EqualityFunctionGenerator.cs
+++ b/Sources/Equ/EqualityFunctionGenerator.cs
@@ -1,7 +1,6 @@
 namespace Equ
 {
     using System;
-    using System.Collections;
     using System.Collections.Generic;
     using System.Linq;
     using System.Linq.Expressions;

--- a/Sources/Equ/EqualityFunctionGenerator.cs
+++ b/Sources/Equ/EqualityFunctionGenerator.cs
@@ -106,11 +106,10 @@ namespace Equ
                 var boxedRightMemberExpr = Expression.Convert(rightMemberExpr, typeof(object));
                 return MakeReferenceTypeEqualExpression(boxedLeftMemberExpr, boxedRightMemberExpr);
             }
-            if (IsSequenceType(memberType))
-            {
-                return MakeSequenceTypeEqualExpression(leftMemberExpr, rightMemberExpr, memberType);
-            }
-            return MakeReferenceTypeEqualExpression(leftMemberExpr, rightMemberExpr);
+
+            return ReflectionUtils.IsSequenceType(memberType)
+                ? MakeSequenceTypeEqualExpression(leftMemberExpr, rightMemberExpr, memberType)
+                : MakeReferenceTypeEqualExpression(leftMemberExpr, rightMemberExpr);
         }
 
         private static Expression MakeSequenceTypeEqualExpression(Expression left, Expression right, Type enumerableType)
@@ -130,7 +129,7 @@ namespace Equ
 
             var memberType = memberAccessExpr.Type;
 
-            var getHashCodeExpr = IsSequenceType(memberType)
+            var getHashCodeExpr = ReflectionUtils.IsSequenceType(memberType)
                 ? MakeCallOnSequenceEqualityComparerExpression("GetHashCode", memberType, memberAccessExpr)
                 : Expression.Call(memberAccessAsObjExpr, "GetHashCode", Type.EmptyTypes);
 
@@ -147,11 +146,6 @@ namespace Equ
             var comparerExpr = Expression.Constant(comparerInstance);
 
             return Expression.Call(comparerExpr, methodName, Type.EmptyTypes, parameterExpressions);
-        }
-
-        private static bool IsSequenceType(Type type)
-        {
-            return typeof(IEnumerable).GetTypeInfo().IsAssignableFrom(type) && type != typeof(string);
         }
     }
 }

--- a/Sources/Equ/MemberwiseEqualityComparer.cs
+++ b/Sources/Equ/MemberwiseEqualityComparer.cs
@@ -4,7 +4,6 @@
     using System.Collections.Generic;
     using System.Linq;
     using System.Reflection;
-    using System.Text.RegularExpressions;
 
     /// <summary>
     /// Provides an implementation of <see cref="IEqualityComparer{T}"/> that performs memberwise

--- a/Sources/Equ/MemberwiseEqualityComparer.cs
+++ b/Sources/Equ/MemberwiseEqualityComparer.cs
@@ -17,9 +17,6 @@
     /// </summary>
     public class MemberwiseEqualityComparer<T> : IEqualityComparer<T>
     {
-        // ReSharper disable once StaticMemberInGenericType
-        private static readonly Regex _autoPropertyBackingFieldRegex = new Regex("^<([a-zA-Z][a-zA-Z0-9]*)>k__BackingField$");
-
         private readonly Func<object, object, bool> _equalsFunc;
 
         private readonly Func<object, int> _getHashCodeFunc;
@@ -67,17 +64,15 @@
             return t.GetTypeInfo().GetProperties(AllInstanceMembers).Where(info => IsNotMarkedAsIgnore(info) && IsNotIndexed(info));
         }
 
-        private static BindingFlags AllInstanceMembers
-        {
-            get { return BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic; }
-        }
+        private static BindingFlags AllInstanceMembers => BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic;
 
         private static bool IsNotMarkedAsIgnore(MemberInfo memberInfo)
         {
             var isSelfIgnored = memberInfo.GetCustomAttributes(typeof(MemberwiseEqualityIgnoreAttribute), true).Any();
 
-            var propertyInfo = GetPropertyForBackingField(memberInfo);
-            var isPropertyIgnored = propertyInfo != null && propertyInfo.GetCustomAttributes(typeof(MemberwiseEqualityIgnoreAttribute), true).Any();
+            var propertyInfo = ReflectionUtils.GetPropertyForBackingField(memberInfo);
+            var isPropertyIgnored = propertyInfo != null
+                                    && propertyInfo.GetCustomAttributes(typeof(MemberwiseEqualityIgnoreAttribute), true).Any();
 
             return !isSelfIgnored && !isPropertyIgnored;
         }
@@ -86,22 +81,7 @@
         {
             var indexParamaters = propertyInfo.GetIndexParameters();
 
-            return indexParamaters.Count() == 0;
-        }
-
-        private static PropertyInfo GetPropertyForBackingField(MemberInfo memberInfo)
-        {
-            if (memberInfo is FieldInfo && _autoPropertyBackingFieldRegex.IsMatch(memberInfo.Name))
-            {
-                var match = _autoPropertyBackingFieldRegex.Match(memberInfo.Name);
-                if (match.Success && match.Groups.Count >= 2 && match.Groups[1].Captures.Count >= 1)
-                {
-                    var propertyName = match.Groups[1].Captures[0].Value;
-                    return memberInfo.DeclaringType.GetTypeInfo().GetProperties().SingleOrDefault(p => p.Name == propertyName);
-                }
-            }
-
-            return null;
+            return !indexParamaters.Any();
         }
 
         /// <summary>

--- a/Sources/Equ/ReflectionUtils.cs
+++ b/Sources/Equ/ReflectionUtils.cs
@@ -1,0 +1,36 @@
+namespace Equ
+{
+    using System;
+    using System.Collections;
+    using System.Linq;
+    using System.Reflection;
+    using System.Text.RegularExpressions;
+
+    public static class ReflectionUtils
+    {
+        private static readonly Regex _autoPropertyBackingFieldRegex = new Regex("^<([a-zA-Z][a-zA-Z0-9]*)>k__BackingField$");
+
+        /// <summary>
+        /// Returns the associated auto property PropertyInfo if <paramref name="memberInfo"/> is a compiler-generated backing field.
+        /// </summary>
+        public static PropertyInfo GetPropertyForBackingField(MemberInfo memberInfo)
+        {
+            if (memberInfo is FieldInfo && _autoPropertyBackingFieldRegex.IsMatch(memberInfo.Name))
+            {
+                var match = _autoPropertyBackingFieldRegex.Match(memberInfo.Name);
+                if (match.Success && match.Groups.Count >= 2 && match.Groups[1].Captures.Count >= 1)
+                {
+                    var propertyName = match.Groups[1].Captures[0].Value;
+                    return memberInfo.DeclaringType.GetTypeInfo().GetProperties().SingleOrDefault(p => p.Name == propertyName);
+                }
+            }
+
+            return null;
+        }
+        
+        public static bool IsSequenceType(Type type)
+        {
+            return typeof(IEnumerable).GetTypeInfo().IsAssignableFrom(type) && type != typeof(string);
+        }
+    }
+}

--- a/Sources/Equ/Stringify.cs
+++ b/Sources/Equ/Stringify.cs
@@ -1,0 +1,18 @@
+namespace Equ
+{
+    using System;
+
+    public static class Stringify<T>
+    {
+        // This is a static field on purpose to make it initialize at static initialization time
+        private static readonly Func<object, string> _toStringMethod = new ToStringFunctionGenerator(typeof(T)).MakeToStringMethod();
+
+        /// <summary>
+        /// Returns a string representation of <paramref name="obj"/> using <see cref="ToStringFunctionGenerator"/>.
+        /// </summary>
+        public static string With(T obj)
+        {
+            return _toStringMethod(obj);
+        }
+    }
+}

--- a/Sources/Equ/Stringify.cs
+++ b/Sources/Equ/Stringify.cs
@@ -2,9 +2,12 @@ namespace Equ
 {
     using System;
 
+    /// <summary>
+    /// Convenience wrapper around <see cref="ToStringFunctionGenerator"/>. *This is currently experimental.*
+    /// </summary>
     public static class Stringify<T>
     {
-        // This is a static field on purpose to make it initialize at static initialization time
+        // This is deliberately a static field to make it initialize at static initialization time
         private static readonly Func<object, string> _toStringMethod = new ToStringFunctionGenerator(typeof(T)).MakeToStringMethod();
 
         /// <summary>

--- a/Sources/Equ/ToStringFunctionGenerator.cs
+++ b/Sources/Equ/ToStringFunctionGenerator.cs
@@ -6,15 +6,18 @@ namespace Equ
     using System.Linq;
     using System.Linq.Expressions;
     using System.Reflection;
-    using System.Text.RegularExpressions;
 
+    /// <summary>
+    /// Generator that produces ToString() functions for arbitrary objects. The functions are composed dynamically using reflection,
+    /// but then compiled for high runtime performance.
+    ///
+    /// NOTE: This class is currently experimental.
+    /// </summary>
     public class ToStringFunctionGenerator
     {                
         private static readonly MethodInfo _stringConcatMethod = typeof(string).GetTypeInfo().GetMethod("Concat", new[] { typeof(string[]) });
         
         private static readonly MethodInfo _objectToStringMethod = typeof(object).GetTypeInfo().GetMethod("ToString");
-
-        private static readonly Regex _autoPropertyBackingFieldRegex = new Regex("^<([a-zA-Z][a-zA-Z0-9]*)>k__BackingField$");
 
         private readonly Type _type;
 

--- a/Sources/Equ/ToStringFunctionGenerator.cs
+++ b/Sources/Equ/ToStringFunctionGenerator.cs
@@ -1,0 +1,91 @@
+namespace Equ
+{
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Linq.Expressions;
+    using System.Reflection;
+    using System.Text.RegularExpressions;
+
+    public class ToStringFunctionGenerator
+    {                
+        private static readonly MethodInfo _stringConcatMethod = typeof(string).GetTypeInfo().GetMethod("Concat", new[] { typeof(string[]) });
+        
+        private static readonly MethodInfo _objectToStringMethod = typeof(object).GetTypeInfo().GetMethod("ToString");
+
+        private static readonly Regex _autoPropertyBackingFieldRegex = new Regex("^<([a-zA-Z][a-zA-Z0-9]*)>k__BackingField$");
+
+        private readonly Type _type;
+
+        public ToStringFunctionGenerator(Type type)
+        {
+            _type = type;
+        }
+
+        /// <summary>
+        /// Returns a compiled lambda that turns an object of type <see cref="_type"/> into its string representation.
+        /// </summary>
+        /// <returns></returns>
+        public Func<object, string> MakeToStringMethod()
+        {
+            var fields = _type.GetTypeInfo().GetFields(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+            
+            var toStringInputParam = Expression.Parameter(typeof(object));
+            var concatExpr = AsObjectString(fields.Select(f => FieldStringRepresentation(f, toStringInputParam)).ToArray());
+
+            return Expression.Lambda<Func<object, string>>(concatExpr, toStringInputParam).Compile();
+        }
+        
+        /// <summary>
+        /// Returns an expression of a string that contains the field name and value.
+        /// </summary>
+        private Expression FieldStringRepresentation(FieldInfo field, Expression instance)
+        {
+            var fieldName = Expression.Constant(GetDisplayName(field) + ": ");
+            var fieldValue = FieldStringValue(field, instance);
+
+            return Expression.Call(_stringConcatMethod, Expression.NewArrayInit(typeof(string), fieldName, fieldValue));
+        }
+
+        private Expression FieldStringValue(FieldInfo field, Expression instance)
+        {
+            var typedInstance = Expression.Convert(instance, _type);
+            var fieldAccess = Expression.MakeMemberAccess(typedInstance, field);
+
+            if (ReflectionUtils.IsSequenceType(field.FieldType))
+            {
+                // The field is a sequence, so call ToString on each element and concatenate
+                var enumerableToStringExpr = (Expression<Func<IEnumerable, string>>)(xs =>
+                    "[ " + string.Join(", ", xs.Cast<object>().Select(x => x.ToString())) + " ]");
+                
+                return Expression.Invoke(enumerableToStringExpr, fieldAccess);
+            }
+            
+            // The field is a scalar, so just call ToString on it
+            return Expression.Call(Expression.Convert(fieldAccess, typeof(object)), _objectToStringMethod);
+        }
+        
+        /// <summary>
+        /// Concatenates the individual string expressions and encloses them in curly braces.
+        /// </summary>
+        private static Expression AsObjectString(params Expression[] stringExpressions)
+        {
+            var concatArgsExpr = Expression.NewArrayInit(typeof(string), stringExpressions);
+            
+            var joinAllAsObj = (Expression<Func<IEnumerable<string>, string>>)(ss => "{ " + string.Join(", ", ss) + " }");
+
+            return Expression.Invoke(joinAllAsObj, concatArgsExpr);
+        }
+        
+        /// <summary>
+        /// Returns a human readable name for the field. If the field is a compiler-generated backing field for an auto property,
+        /// the property name is used. Otherwise the field name is used.
+        /// </summary>
+        private static string GetDisplayName(FieldInfo field)
+        {
+            var autoPropertyInfo = ReflectionUtils.GetPropertyForBackingField(field);
+            return autoPropertyInfo == null ? field.Name : autoPropertyInfo.Name;
+        }
+    }
+}


### PR DESCRIPTION
The end goal is to include this in `MemberwiseEquatable` and `PropertywiseEquatable`, but we first need some field experience with the generator. For the moment, it must be added manually through

```
public override string ToString() => Stringify<SomeType2>.With(this);
```